### PR TITLE
fix filename in vmx

### DIFF
--- a/esxi/ghetto-esxi-linked-clones.sh
+++ b/esxi/ghetto-esxi-linked-clones.sh
@@ -615,7 +615,7 @@ do
     # collect all the vmids in case user wants us to shut them down
     all_vmids="${all_vmids}${FINAL_VM_VMID} "
     # set the file path to the correct directory
-    sed -ir 's|scsi0:0.fileName = ".*"|scsi0:0.fileName ="'${FINAL_VMDK_PATH}'"|' $FINAL_VMX_PATH
+    sed -i -r 's|scsi0:0.fileName = "[^"]+"|scsi0:0.fileName ="'${FINAL_VMDK_PATH}'"|' $FINAL_VMX_PATH
 
     # start the vm so it will get a new mac etc
     echo "[*] Starting VM:  ${FINAL_VM_VMID}"

--- a/esxi/ghetto-esxi-linked-clones.sh
+++ b/esxi/ghetto-esxi-linked-clones.sh
@@ -615,7 +615,7 @@ do
     # collect all the vmids in case user wants us to shut them down
     all_vmids="${all_vmids}${FINAL_VM_VMID} "
     # set the file path to the correct directory
-    sed -ir 's|scsi0:0.fileName = "[^"]+"|scsi0:0.fileName ="'${FINAL_VMDK_PATH}'"|' $FINAL_VMX_PATH
+    sed -ir 's|scsi0:0.fileName = ".*"|scsi0:0.fileName ="'${FINAL_VMDK_PATH}'"|' $FINAL_VMX_PATH
 
     # start the vm so it will get a new mac etc
     echo "[*] Starting VM:  ${FINAL_VM_VMID}"


### PR DESCRIPTION
datastore path is changed to format in uuid, eg: /vmfs/volumes/5db02d11-9048f6fa-b5ed-98039b594cf4/vm-1/vm-000001.vmdk